### PR TITLE
refact: remove items_per_merchant

### DIFF
--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -25,12 +25,6 @@ class MerchantRepository < GeneralRepo
     end
   end
 
-  def items_per_merchant
-    all.map do |merchant|
-      merchant._items
-    end
-  end
-
   def average_items_per_merchant
     average(number_of_items_per_merchant.sum, all.length).round(2)
   end
@@ -86,7 +80,6 @@ class MerchantRepository < GeneralRepo
     average(total_avg_item_prices, all.length).round(2)
   end
 
-
   def merchants_with_only_one_item
     all.select { |merchant| merchant.item_count == 1 }
   end
@@ -100,7 +93,7 @@ class MerchantRepository < GeneralRepo
   def merchants_with_pending_invoices
     all.select { |merchant| merchant.invoice_pending? }
   end
-  
+
   def top_revenue_earners(num)
     sorted = all.sort_by do |merchant|
       -merchant.revenue

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -39,11 +39,7 @@ class SalesEngine
   def number_of_items_per_merchant
     @merchants.number_of_items_per_merchant
   end
-
-  def items_per_merchant
-    @merchants.items_per_merchant
-  end
-
+  
   def average_items_per_merchant_standard_deviation
     @merchants.average_items_per_merchant_standard_deviation
   end

--- a/spec/merchant_repository_spec.rb
+++ b/spec/merchant_repository_spec.rb
@@ -89,18 +89,7 @@ describe MerchantRepository do
       expect(mr.number_of_items_per_merchant).to eq [2, 2, 2, 2]
     end
   end
-
-  describe '#items_per_merchant' do
-    it 'returns a list of items per merchant' do
-      allow(mr.all[0]).to receive(:_items).and_return(['item'])
-      allow(mr.all[1]).to receive(:_items).and_return(['item1', 'item2'])
-      allow(mr.all[2]).to receive(:_items).and_return(['item', 'item2', 'item3'])
-      allow(mr.all[3]).to receive(:_items).and_return(['item'])
-
-      expect(mr.items_per_merchant).to eq [['item'], ['item1', 'item2'], ['item', 'item2', 'item3'], ['item']]
-    end
-  end
-
+  
   describe '#average_items_per_merchant' do
     it 'returns the average number of items per merchant' do
       allow(mr.all[0]).to receive(:_items).and_return(['item'])


### PR DESCRIPTION
Removes items_per_merchant and some extra whitespace in the merchant_repo